### PR TITLE
Upgrade script to handle arbitrary number of template files

### DIFF
--- a/menu-translations/appearance_ar
+++ b/menu-translations/appearance_ar
@@ -1,0 +1,27 @@
+[begin] (مظهر) 
+    [exec] (كونكي){conky-manager2}
+    [submenu] (شرائطالتطبيقات)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (افتراضي) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (معدّلشريط التطبيقات) {mx-dockmaker}
+    [end]
+    [exec] (أيقونات سطح المكتب) {mx-idesktool}
+    [exec] (الشاشات) {gkrellm}
+    [submenu] (نسق)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (السمات) {lxappearance}
+    [submenu] (شريط الأدوات)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (المظهر) {toggletint2}
+    [end]
+    [submenu] (خلفية) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_de
+++ b/menu-translations/appearance_de
@@ -1,0 +1,27 @@
+[begin] (Aussehen) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Docks)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Standardmäßig) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Desktop-Symbole) {mx-idesktool}
+    [exec] (Überwacht) {gkrellm}
+    [submenu] (Stil)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Thema) {lxappearance}
+    [submenu] (Symbolleiste)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (التقليدي) {toggletint2}
+    [end]
+    [submenu] (الشاشة) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_el
+++ b/menu-translations/appearance_el
@@ -1,0 +1,27 @@
+[begin] (Εμφάνιση) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Docks)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Προκαθορισμένο) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Εικονίδια επιφάνειας εργασίας) {mx-idesktool}
+    [exec] (Έλεγχος) {gkrellm}
+    [submenu] (Στυλ)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Θέμα) {lxappearance}
+    [submenu] (Γραμμή εργαλείων)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Aspecto) {toggletint2}
+    [end]
+    [submenu] (de) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_en
+++ b/menu-translations/appearance_en
@@ -1,0 +1,27 @@
+[begin] (Appearance) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Docks)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Default) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Desktop icons) {mx-idesktool}
+    [exec] (Monitors) {gkrellm}
+    [submenu] (Style)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Theme) {lxappearance}
+    [submenu] (Toolbar)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Traditional) {toggletint2}
+    [end]
+    [submenu] (Wallpaper) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_es
+++ b/menu-translations/appearance_es
@@ -1,0 +1,27 @@
+[begin] (Mira) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Muelles)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Por defecto) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Iconos de escritorio) {mx-idesktool}
+    [exec] (Monitores) {gkrellm}
+    [submenu] (Estilo)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Tema) {lxappearance}
+    [submenu] (Barra de herramientas)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Traditionelles) {toggletint2}
+    [end]
+    [submenu] (Bildschirmhintergrund) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_fr
+++ b/menu-translations/appearance_fr
@@ -1,0 +1,27 @@
+[begin] (Regardez) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Docks)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Par défaut) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Icônes de bureau) {mx-idesktool}
+    [exec] (Surveille) {gkrellm}
+    [submenu] (Style)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Thème) {lxappearance}
+    [submenu] (Barre d’outils)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Aussehen) {toggletint2}
+    [end]
+    [submenu] (Fondo) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_id
+++ b/menu-translations/appearance_id
@@ -1,0 +1,27 @@
+[begin] (Tampilan) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Docks)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Setelan Bawaan) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (DockMaker) {mx-dockmaker}
+    [end]
+    [exec] (Ikon Desktop) {mx-idesktool}
+    [exec] (Layar) {gkrellm}
+    [submenu] (Gaya)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Tema) {lxappearance}
+    [submenu] (Bilah Alat)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (tradicional) {toggletint2}
+    [end]
+    [submenu] (pantalla) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_it
+++ b/menu-translations/appearance_it
@@ -1,0 +1,27 @@
+[begin] (Guarda) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Darsene)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Predefinito) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Icone da tavolo) {mx-idesktool}
+    [exec] (Monitor) {gkrellm}
+    [submenu] (Stile)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Tema) {lxappearance}
+    [submenu] (Barra degli strumenti)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Aspect) {toggletint2}
+    [end]
+    [submenu] (Fond) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_nl
+++ b/menu-translations/appearance_nl
@@ -1,0 +1,27 @@
+[begin] (Verschijning) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Dokken)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Standaard) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Bureaupictogrammen) {mx-idesktool}
+    [exec] (Monitoren) {gkrellm}
+    [submenu] (Stijl)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Thema) {lxappearance}
+    [submenu] (Werkbalk)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (traditionnel) {toggletint2}
+    [end]
+    [submenu] (d'écran) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_pl
+++ b/menu-translations/appearance_pl
@@ -1,0 +1,27 @@
+[begin] (Wygląd) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Doki)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Domyślny) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Ikony pulpitu) {mx-idesktool}
+    [exec] (Monitory) {gkrellm}
+    [submenu] (Styl)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Motyw) {lxappearance}
+    [submenu] (Pasek narzędzi)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Παραδοσιακή) {toggletint2}
+    [end]
+    [submenu] (Ταπετσαρία) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_pt
+++ b/menu-translations/appearance_pt
@@ -1,0 +1,27 @@
+[begin] (Veja) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Docas)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Por defeito) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Ícones do ambiente de trabalho) {mx-idesktool}
+    [exec] (Monitores) {gkrellm}
+    [submenu] (Estilo)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Tema) {lxappearance}
+    [submenu] (Barra de ferramentas)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (εμφάνιση) {toggletint2}
+    [end]
+    [submenu] (Wallpaper) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_pt_BR
+++ b/menu-translations/appearance_pt_BR
@@ -1,0 +1,27 @@
+[begin] (Aparência) 
+    [exec] (Conky){conky-manager2}
+    [submenu] (Docks)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (Padrão) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Dockmaker) {mx-dockmaker}
+    [end]
+    [exec] (Ícones da área de trabalho) {mx-idesktool}
+    [exec] (Monitores) {gkrellm}
+    [submenu] (Estilo)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Tema) {lxappearance}
+    [submenu] (Barra de ferramentas)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Tampilan) {toggletint2}
+    [end]
+    [submenu] (Carta) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/appearance_ru
+++ b/menu-translations/appearance_ru
@@ -1,0 +1,27 @@
+[begin] (Посмотреть) 
+    [exec] (Conky Конки){conky-manager2}
+    [submenu] (Доки)
+        [exec] (Work) {~/.fluxbox/scripts/Work.mxdk}
+        [exec] (MyDefault) {~/.fluxbox/scripts/MyDefaultDock.mxdk}
+        [exec] (По умолчанию) {~/.fluxbox/scripts/DefaultDock.mxdk}
+        [separator]
+        [exec] (Докмейкер) {mx-dockmaker}
+    [end]
+    [exec] (Иконки рабочего стола) {mx-idesktool}
+    [exec] (Мониторы) {gkrellm}
+    [submenu] (Стиль)
+        [stylesdir] (~/.fluxbox/styles)
+        [separator]
+        [stylesdir] (/usr/share/fluxbox/styles) 
+    [end]
+    [exec] (Тема) {lxappearance}
+    [submenu] (Панель инструментов)
+        [exec] (Fluxbox) {toggletint2}
+        [exec] (Tradisional) {toggletint2}
+    [end]
+    [submenu] (da) 
+    [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
+    [separator]
+    [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
+    [end]
+[end]

--- a/menu-translations/menu-mx_ar
+++ b/menu-translations/menu-mx_ar
@@ -1,20 +1,20 @@
 [begin] (Fluxbox) 
     [exec] (حول) {about-mx-fluxbox}
     [exec] (جميع التطبيقات) {rofi -show drun}
-    [exec] (المتصفح) {firefox}
-    [exec] (البريد الإلكتروني) {thunderbird}
+    [exec] (المتصفحالإلكتروني) {firefox}
+    [exec] (البريد) {thunderbird}
     [exec] (مدير الملفات) {thunar $HOME/.fluxbox} 
     [exec] (مساعدة) {thunar /usr/share/mxflux/help}
     [exec] (موسيقى) {clementine}
-    [exec] (Run  تشغيل) {fbrun} 
-    [exec] (Terminal طرفية) {xfce4-terminal} 
+    [exec] (تشغيل) {fbrun} 
+    [exec] (طرفية) {xfce4-terminal} 
     [separator]
     [submenu] (مظهر) 
-        [exec] (كونكي Conky){conky-manager2}
-        [submenu] (شرائط التطبيقات)
+        [exec] (كونكي){conky-manager2}
+        [submenu] (شرائطالتطبيقات)
             [exec] (افتراضي) {~/.fluxbox/scripts/DefaultDock.mxdk}
             [separator]
-            [exec] (معدّل شريط التطبيقات) {mx-dockmaker}
+            [exec] (معدّلشريط التطبيقات) {mx-dockmaker}
         [end]
         [exec] (أيقونات سطح المكتب) {mx-idesktool}
         [exec] (الشاشات) {gkrellm}
@@ -26,9 +26,9 @@
         [exec] (السمات) {lxappearance}
         [submenu] (شريط الأدوات)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (المظهر التقليدي) {toggletint2}
+            [exec] (المظهر) {toggletint2}
         [end]
-        [submenu] (خلفية الشاشة)
+        [submenu] (خلفية)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
@@ -40,11 +40,11 @@
             [exec] (Init) {xdg-open ~/.fluxbox/init}
             [exec] (مفاتيح) {xdg-open ~/.fluxbox/keys}
             [exec] (قائمة) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Overlay  تراكب) {xdg-open ~/.fluxbox/overlay}
-            [exec] (بدء التشغيل) {featherpad ~/.fluxbox/startup}
+            [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
+            [exec] (بدء) {featherpad ~/.fluxbox/startup}
             [exec] (أنماط) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (لوحة المفاتيح)
+        [submenu] (لوحة)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (خارج النظر)
-            [exec] (إنهاء شريط التطبيقات) { killall wmalauncher               }
-    [exec] (انهاء نافذة) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (إيقاف/تشغيل Conky) { conkytoggle.sh                    }
-    [exec] (إيقاف/تشغيل iDesk) { idesktoggle idesk                 }
-    [exec] (إظهار/إخفاء الأيقونات) { idesktoggle icons                 }
-    [exec] (إيقاف/تشغيل الاخفاء التلقائي لشريط التطبيقات) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (إيقاف/تشغيل الاخفاء التلقائي لشريط الأدوات) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (تبديل الشاشات) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (تعطيل شريط التطبيقات الافتراضي) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
     [submenu] (مغادرة)
         [exec] (تحديث) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (تعليق) {sudo 'pm-suspend'}
-        [exit] (تسجيل الخروج) 
-        [exec] (إعادة التشغيل) {sudo /sbin/reboot} 
-        [exec] (إيقاف التشغيل) {sudo /sbin/halt}
+        [exit] (تسجيل) 
+        [exec] (إعادة) {sudo /sbin/reboot} 
+        [exec] (إيقاف) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_de
+++ b/menu-translations/menu-mx_de
@@ -6,7 +6,7 @@
     [exec] (Datei-Manager) {thunar $HOME/.fluxbox} 
     [exec] (Hilfe) {thunar /usr/share/mxflux/help}
     [exec] (Musik) {clementine}
-    [exec] (Führen Sie  aus.) {fbrun} 
+    [exec] (Führen Sie aus) {fbrun} 
     [exec] (Terminal) {xfce4-terminal} 
     [separator]
     [submenu] (Aussehen) 
@@ -26,25 +26,25 @@
         [exec] (Thema) {lxappearance}
         [submenu] (Symbolleiste)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Traditionelles Aussehen) {toggletint2}
+            [exec] (التقليدي) {toggletint2}
         [end]
-        [submenu] (Bildschirmhintergrund)
+        [submenu] (الشاشة)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Einstellungen)
-        [submenu] (Konfigurieren Sie)
+        [submenu] (Konfigurieren)
             [exec] (Anwendungen) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
             [exec] (Schlüssel) {xdg-open ~/.fluxbox/keys}
             [exec] (Menü) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Überlagerung) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Neugründung) {featherpad ~/.fluxbox/startup}
+            [exec] () {xdg-open ~/.fluxbox/overlay}
+            [exec] (التشغيل) {featherpad ~/.fluxbox/startup}
             [exec] (Stile) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Tastatur)
+        [submenu] (المفاتيح)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Außer Sichtweite)
-            [exec] (Killdock) { killall wmalauncher               }
-    [exec] (Ein Fenster töten) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Umschalten conky) { conkytoggle.sh                    }
-    [exec] (iDesk umschalten) { idesktoggle idesk                 }
-    [exec] (Symbole umschalten) { idesktoggle icons                 }
-    [exec] (Autohide-Dock umschalten) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Umschalten der Autohide-Werkzeugleiste) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Monitore umschalten) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Standard-Dock deaktivieren) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Verlassen Sie)
-        [exec] (Aktualisieren Sie) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Verlassen)
+        [exec] (Aktualisieren) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (aussetzen) {sudo 'pm-suspend'}
-        [exit] (Abmeldung) 
-        [exec] (Neustart) {sudo /sbin/reboot} 
-        [exec] (Herunterfahren) {sudo /sbin/halt}
+        [exit] (الخروج) 
+        [exec] (التشغيل) {sudo /sbin/reboot} 
+        [exec] (التشغيل) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_el
+++ b/menu-translations/menu-mx_el
@@ -26,25 +26,25 @@
         [exec] (Θέμα) {lxappearance}
         [submenu] (Γραμμή εργαλείων)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Παραδοσιακή εμφάνιση) {toggletint2}
+            [exec] (Aspecto) {toggletint2}
         [end]
-        [submenu] (Ταπετσαρία)
+        [submenu] (de)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Ρυθμίσεις)
-        [submenu] (Διαμόρφωση)
+        [submenu] (Configurer)
             [exec] (Εφαρμογές) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
             [exec] (Keys) {xdg-open ~/.fluxbox/keys}
             [exec] (Μενού) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Επικάλυμμα) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Superposición) {xdg-open ~/.fluxbox/overlay}
             [exec] (Startup) {featherpad ~/.fluxbox/startup}
             [exec] (Στυλ) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Πληκτρολόγιο)
+        [submenu] (Clavier)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Κρυμμένα)
-            [exec] (Τερματισμός dock) { killall wmalauncher               }
-    [exec] (Τερματισμός παραθύρου) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Εναλλαγή conky) { conkytoggle.sh                    }
-    [exec] (Εναλλαγή iDesk) { idesktoggle idesk                 }
-    [exec] (Εναλλαγή εικονιδίων) { idesktoggle icons                 }
-    [exec] (Εναλλαγή autohide dock) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Εναλλαγή autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Εναλλαγή monitors) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Απενεργοποίηση προεπιλεγμένο dock) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Εξοδος)
-        [exec] (Ανανέωση) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Quitter)
+        [exec] (Rafraîchir) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Αναστολή) {sudo 'pm-suspend'}
-        [exit] (Αποσύνδεση) 
-        [exec] (Επανεκκινήση) {sudo /sbin/reboot} 
-        [exec] (Τερματισμός) {sudo /sbin/halt}
+        [exit] (de) 
+        [exec] (Redémarrer) {sudo /sbin/reboot} 
+        [exec] (Fermeture) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_en
+++ b/menu-translations/menu-mx_en
@@ -1,50 +1,50 @@
 [begin] (Fluxbox) 
-    [exec] (À propos…) {about-mx-fluxbox}
-    [exec] (Toutes les applications) {rofi -show drun}
-    [exec] (Navigateur) {firefox}
-    [exec] (Courriel) {thunderbird}
-    [exec] (Gestionnaire de fichiers) {thunar $HOME/.fluxbox} 
-    [exec] (Aide) {thunar /usr/share/mxflux/help}
-    [exec] (Musique) {clementine}
-    [exec] (Courir) {fbrun} 
+    [exec] (About) {about-mx-fluxbox}
+    [exec] (All apps) {rofi -show drun}
+    [exec] (Browser) {firefox}
+    [exec] (Email) {thunderbird}
+    [exec] (File manager) {thunar $HOME/.fluxbox} 
+    [exec] (Help) {thunar /usr/share/mxflux/help}
+    [exec] (Music) {clementine}
+    [exec] (Run) {fbrun} 
     [exec] (Terminal) {xfce4-terminal} 
     [separator]
-    [submenu] (Regardez) 
+    [submenu] (Appearance) 
         [exec] (Conky){conky-manager2}
         [submenu] (Docks)
-            [exec] (Par défaut) {~/.fluxbox/scripts/DefaultDock.mxdk}
+            [exec] (Default) {~/.fluxbox/scripts/DefaultDock.mxdk}
             [separator]
             [exec] (Dockmaker) {mx-dockmaker}
         [end]
-        [exec] (Icônes de bureau) {mx-idesktool}
-        [exec] (Surveille) {gkrellm}
+        [exec] (Desktop icons) {mx-idesktool}
+        [exec] (Monitors) {gkrellm}
         [submenu] (Style)
             [stylesdir] (~/.fluxbox/styles)
             [separator]
             [stylesdir] (/usr/share/fluxbox/styles) 
         [end]
-        [exec] (Thème) {lxappearance}
-        [submenu] (Barre d’outils)
+        [exec] (Theme) {lxappearance}
+        [submenu] (Toolbar)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Aussehen) {toggletint2}
+            [exec] (Traditional) {toggletint2}
         [end]
-        [submenu] (Fondo)
+        [submenu] (Wallpaper)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
-    [submenu] (Paramètres)
-        [submenu] (Configurar)
+    [submenu] (Settings)
+        [submenu] (Configure)
             [exec] (Apps) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
-            [exec] (Clés) {xdg-open ~/.fluxbox/keys}
+            [exec] (Keys) {xdg-open ~/.fluxbox/keys}
             [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Überlagerung) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Inicio) {featherpad ~/.fluxbox/startup}
+            [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Startup) {featherpad ~/.fluxbox/startup}
             [exec] (Styles) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Teclado)
+        [submenu] (Keyboard)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -74,11 +74,11 @@
     [separator]
     [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Deje)
-        [exec] (Actualizar) { fluxbox-remote restart; idesktoggle idesk refresh }
-        [exec] (Suspendre) {sudo 'pm-suspend'}
-        [exit] (Cierre) 
-        [exec] (Reiniciar) {sudo /sbin/reboot} 
-        [exec] (Apagado) {sudo /sbin/halt}
+    [submenu] (Leave)
+        [exec] (Refresh) { fluxbox-remote restart; idesktoggle idesk refresh }
+        [exec] (Suspend) {sudo 'pm-suspend'}
+        [exit] (Logout) 
+        [exec] (Reboot) {sudo /sbin/reboot} 
+        [exec] (Shutdown) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_es
+++ b/menu-translations/menu-mx_es
@@ -1,5 +1,5 @@
 [begin] (Fluxbox) 
-    [exec] (Acerca de...) {about-mx-fluxbox}
+    [exec] (Acerca de…) {about-mx-fluxbox}
     [exec] (Todas las aplicaciones) {rofi -show drun}
     [exec] (Navegador) {firefox}
     [exec] (Correo electrónico) {thunderbird}
@@ -26,25 +26,25 @@
         [exec] (Tema) {lxappearance}
         [submenu] (Barra de herramientas)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Aspecto tradicional) {toggletint2}
+            [exec] (Traditionelles) {toggletint2}
         [end]
-        [submenu] (Fondo de pantalla)
+        [submenu] (Bildschirmhintergrund)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Ajustes)
-        [submenu] (Configurar)
+        [submenu] (Sie)
             [exec] (Aplicaciones) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
             [exec] (Llaves) {xdg-open ~/.fluxbox/keys}
             [exec] (Menú) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Superposición) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Inicio) {featherpad ~/.fluxbox/startup}
+            [exec] (تراكب) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Neugründung) {featherpad ~/.fluxbox/startup}
             [exec] (Estilos) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Teclado)
+        [submenu] (Tastatur)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Fuera de la vista)
-            [exec] (Muelle de la muerte) { killall wmalauncher               }
-    [exec] (Matar una ventana) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Cambiar conky...) { conkytoggle.sh                    }
-    [exec] (Cambiar el iDesk) { idesktoggle idesk                 }
-    [exec] (Iconos de conmutación) { idesktoggle icons                 }
-    [exec] (Cambiar el muelle de auto-ocultación) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Cambiar la barra de herramientas de auto-ocultación) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Cambiar los monitores...) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Deshabilitar el acoplamiento por defecto) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Deje)
-        [exec] (Actualizar) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Sie)
+        [exec] (Sie) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Suspender) {sudo 'pm-suspend'}
-        [exit] (Cierre de sesión) 
-        [exec] (Reiniciar) {sudo /sbin/reboot} 
-        [exec] (Apagado) {sudo /sbin/halt}
+        [exit] (Abmeldung) 
+        [exec] (Neustart) {sudo /sbin/reboot} 
+        [exec] (Herunterfahren) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_id
+++ b/menu-translations/menu-mx_id
@@ -26,25 +26,25 @@
         [exec] (Tema) {lxappearance}
         [submenu] (Bilah Alat)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Tampilan Tradisional) {toggletint2}
+            [exec] (tradicional) {toggletint2}
         [end]
-        [submenu] (Wallpaper)
+        [submenu] (pantalla)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Setelan)
-        [submenu] (Konfigurasi)
+        [submenu] (Διαμόρφωση)
             [exec] (Aplikasi) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
             [exec] (Tombol) {xdg-open ~/.fluxbox/keys}
             [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Lembaran Atas) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Memulai) {featherpad ~/.fluxbox/startup}
+            [exec] (Superposition) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Startup) {featherpad ~/.fluxbox/startup}
             [exec] (Gaya) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Papan Ketik)
+        [submenu] (Πληκτρολόγιο)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Diluar Pandangan)
-            [exec] (Matikan Dock) { killall wmalauncher               }
-    [exec] (Matikan Jendela) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Tombol Conky) { conkytoggle.sh                    }
-    [exec] (Tombol iDesk) { idesktoggle idesk                 }
-    [exec] (Tombol ikon) { idesktoggle icons                 }
-    [exec] (Tombol sembunyikan otomatis dock) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Tombol sembunyikan otomatis bilah alat) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Tombol monitor) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Matikan setelan bawaan dock) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Meninggalkan)
-        [exec] (Segarkan) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Εξοδος)
+        [exec] (Ανανέωση) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Suspend) {sudo 'pm-suspend'}
-        [exit] (Keluar) 
-        [exec] (Mulai ulang) {sudo /sbin/reboot} 
-        [exec] (Matikan) {sudo /sbin/halt}
+        [exit] (sesión) 
+        [exec] (Επανεκκινήση) {sudo /sbin/reboot} 
+        [exec] (Τερματισμός) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_it
+++ b/menu-translations/menu-mx_it
@@ -2,7 +2,7 @@
     [exec] (Info...) {about-mx-fluxbox}
     [exec] (Tutte le applicazioni) {rofi -show drun}
     [exec] (Browser) {firefox}
-    [exec] (Invia un'e-mail a) {thunderbird}
+    [exec] (E-mail) {thunderbird}
     [exec] (File manager) {thunar $HOME/.fluxbox} 
     [exec] (Aiuto) {thunar /usr/share/mxflux/help}
     [exec] (Musica) {clementine}
@@ -26,25 +26,25 @@
         [exec] (Tema) {lxappearance}
         [submenu] (Barra degli strumenti)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Look tradizionale) {toggletint2}
+            [exec] (Aspect) {toggletint2}
         [end]
-        [submenu] (Carta da parati)
+        [submenu] (Fond)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Impostazioni)
-        [submenu] (Configurare)
+        [submenu] (Konfigurasi)
             [exec] (Applicazioni) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
             [exec] (Tasti) {xdg-open ~/.fluxbox/keys}
             [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Sovrapposizione) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Avvio) {featherpad ~/.fluxbox/startup}
+            [exec] (Επικάλυμμα) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Memulai) {featherpad ~/.fluxbox/startup}
             [exec] (Stili) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Tastiera)
+        [submenu] (Papan)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Lontano dagli occhi)
-            [exec] (Kill dock) { killall wmalauncher               }
-    [exec] (Uccidere una finestra) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Attivare e disattivare il conky) { conkytoggle.sh                    }
-    [exec] (Attivare e disattivare l'iDesk) { idesktoggle idesk                 }
-    [exec] (Icone a levetta) { idesktoggle icons                 }
-    [exec] (Attivare il dock autohide) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Attivare e disattivare la barra degli strumenti autohide) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Monitor a levetta) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Disattivare il dock di default) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Lascia)
-        [exec] (Aggiorna) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Meninggalkan)
+        [exec] (Segarkan) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Sospendi) {sudo 'pm-suspend'}
-        [exit] (Logout) 
-        [exec] (Riavvio) {sudo /sbin/reboot} 
-        [exec] (Spegnimento) {sudo /sbin/halt}
+        [exit] (Déconnexion) 
+        [exec] (Mulai) {sudo /sbin/reboot} 
+        [exec] (Matikan) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_nl
+++ b/menu-translations/menu-mx_nl
@@ -6,7 +6,7 @@
     [exec] (Bestandsmanager) {thunar $HOME/.fluxbox} 
     [exec] (Help) {thunar /usr/share/mxflux/help}
     [exec] (Muziek) {clementine}
-    [exec] (Voer de campagne  uit.) {fbrun} 
+    [exec] (Voer uit) {fbrun} 
     [exec] (Terminal) {xfce4-terminal} 
     [separator]
     [submenu] (Verschijning) 
@@ -26,25 +26,25 @@
         [exec] (Thema) {lxappearance}
         [submenu] (Werkbalk)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Traditionele uitstraling) {toggletint2}
+            [exec] (traditionnel) {toggletint2}
         [end]
-        [submenu] (Behang)
+        [submenu] (d'écran)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Instellingen)
-        [submenu] (Configureer)
+        [submenu] (Configurare)
             [exec] (Apps) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
             [exec] (Toetsen) {xdg-open ~/.fluxbox/keys}
             [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Opstarten) {featherpad ~/.fluxbox/startup}
+            [exec] (Lembaran) {xdg-open ~/.fluxbox/overlay}
+            [exec] () {featherpad ~/.fluxbox/startup}
             [exec] (Stijlen) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Toetsenbord)
+        [submenu] (Ketik)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Uit het zicht)
-            [exec] (Dodendok) { killall wmalauncher               }
-    [exec] (Dood een venster) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Schakelen tussen conky) { conkytoggle.sh                    }
-    [exec] (Schakel iDesk) { idesktoggle idesk                 }
-    [exec] (Schakelen tussen pictogrammen) { idesktoggle icons                 }
-    [exec] (Schakelaar voor autodokker) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Schakel de autohide-werkbalk in) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Schakelen tussen de monitoren) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Standaard dok uitschakelen) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Verlaat)
-        [exec] (Vernieuwen) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Lascia)
+        [exec] (Aggiorna) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Schorsen) {sudo 'pm-suspend'}
-        [exit] (Uitloggen) 
-        [exec] (Herstart) {sudo /sbin/reboot} 
-        [exec] (Uitschakeling) {sudo /sbin/halt}
+        [exit] (Αποσύνδεση) 
+        [exec] (ulang) {sudo /sbin/reboot} 
+        [exec] (Spegnimento) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_pl
+++ b/menu-translations/menu-mx_pl
@@ -26,25 +26,25 @@
         [exec] (Motyw) {lxappearance}
         [submenu] (Pasek narzędzi)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Domyślny wygląd) {toggletint2}
+            [exec] (Παραδοσιακή) {toggletint2}
         [end]
-        [submenu] (Tapeta)
+        [submenu] (Ταπετσαρία)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Ustawienia)
-        [submenu] (Konfiguracja)
+        [submenu] (Configureer)
             [exec] (Aplikacje) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
-            [exec] (Skróty klawiszowe) {xdg-open ~/.fluxbox/keys}
+            [exec] (Skróty) {xdg-open ~/.fluxbox/keys}
             [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Nakładka graficzna) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Autostart) {featherpad ~/.fluxbox/startup}
+            [exec] (Atas) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Avvio) {featherpad ~/.fluxbox/startup}
             [exec] (Style) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Klawiatura)
+        [submenu] (Tastiera)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Ukryj)
-            [exec] (Zabij dock) { killall wmalauncher               }
-    [exec] (Zabij okno) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Przełącznik Conky) { conkytoggle.sh                    }
-    [exec] (Przełącznik iDesk) { idesktoggle idesk                 }
-    [exec] (Przełącznik ikon pulpitu) { idesktoggle icons                 }
-    [exec] (Przełącznik autoukrywania docku) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Przełącznik autoukrywania paska narzędzi) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Przełącznik monitorów) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Wyłącz domyślny dock) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Wyjdź)
-        [exec] (Odśwież) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Verlaat)
+        [exec] (Vernieuwen) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Wstrzymaj) {sudo 'pm-suspend'}
-        [exit] (Wyloguj) 
-        [exec] (Uruchom ponownie) {sudo /sbin/reboot} 
-        [exec] (Zamknij) {sudo /sbin/halt}
+        [exit] (Keluar) 
+        [exec] (Riavvio) {sudo /sbin/reboot} 
+        [exec] (Uitschakeling) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_pt
+++ b/menu-translations/menu-mx_pt
@@ -1,18 +1,18 @@
 [begin] (Fluxbox) 
     [exec] (Sobre...) {about-mx-fluxbox}
     [exec] (Todas as aplicações) {rofi -show drun}
-    [exec] (Navegador de Internet) {firefox}
-    [exec] (Correio electrónico) {thunderbird}
+    [exec] (Browser) {firefox}
+    [exec] (Email) {thunderbird}
     [exec] (Gestor de ficheiros) {thunar $HOME/.fluxbox} 
     [exec] (Ajuda) {thunar /usr/share/mxflux/help}
     [exec] (Música) {clementine}
-    [exec] (Executar) {fbrun} 
+    [exec] (Corre) {fbrun} 
     [exec] (Terminal) {xfce4-terminal} 
     [separator]
-    [submenu] (Ver) 
+    [submenu] (Veja) 
         [exec] (Conky){conky-manager2}
         [submenu] (Docas)
-            [exec] (Padrão) {~/.fluxbox/scripts/DefaultDock.mxdk}
+            [exec] (Por defeito) {~/.fluxbox/scripts/DefaultDock.mxdk}
             [separator]
             [exec] (Dockmaker) {mx-dockmaker}
         [end]
@@ -26,7 +26,7 @@
         [exec] (Tema) {lxappearance}
         [submenu] (Barra de ferramentas)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Aspecto tradicional) {toggletint2}
+            [exec] (εμφάνιση) {toggletint2}
         [end]
         [submenu] (Wallpaper)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
@@ -35,16 +35,16 @@
         [end]
     [end]
     [submenu] (Definições)
-        [submenu] (Configurar)
-            [exec] (Aplicações) {xdg-open ~/.fluxbox/apps}
+        [submenu] (Konfiguracja)
+            [exec] (Apps) {xdg-open ~/.fluxbox/apps}
             [exec] (Init) {xdg-open ~/.fluxbox/init}
-            [exec] (Teclas) {xdg-open ~/.fluxbox/keys}
-            [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx_pt}
-            [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Arranque) {featherpad ~/.fluxbox/startup}
+            [exec] (klawiszowe) {xdg-open ~/.fluxbox/keys}
+            [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+            [exec] (Sovrapposizione) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Opstarten) {featherpad ~/.fluxbox/startup}
             [exec] (Estilos) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Teclado)
+        [submenu] (Toetsenbord)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -58,27 +58,27 @@
 			      [exec] (US) {setxkbmap us}
         [end]
         [config] (Fluxbox)
-        [exec] (Gestor de configurações do Xfce) {xfce4-settings-manager}
+        [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Fora de vista)
-            [exec] (Desactivar doca) { killall wmalauncher               }
-    [exec] (Matar uma janela) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Alternar conky) { conkytoggle.sh                    }
-    [exec] (Alternar iDesk) { idesktoggle idesk                 }
-    [exec] (Alternar ícones) { idesktoggle icons                 }
-    [exec] (Alternar a doca de autoculto) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Alternar ocultação automática da barra de ferramentas) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Alternar Monitores) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Desactivar a doca padrão) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Sair)
-        [exec] (Atualizar) { fluxbox-remote restart; idesktoggle idesk refresh }
-        [exec] (Suspender) {sudo 'pm-suspend'}
-        [exit] (Encerrar sessão) 
-        [exec] (Reinicializar) {sudo /sbin/reboot} 
-        [exec] (Desligar) {sudo /sbin/halt}
+    [submenu] (Wyjdź)
+        [exec] (Odśwież) { fluxbox-remote restart; idesktoggle idesk refresh }
+        [exec] (Suspendam) {sudo 'pm-suspend'}
+        [exit] (Logout) 
+        [exec] (Herstart) {sudo /sbin/reboot} 
+        [exec] (Zamknij) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_pt_BR
+++ b/menu-translations/menu-mx_pt_BR
@@ -26,9 +26,9 @@
         [exec] (Tema) {lxappearance}
         [submenu] (Barra de ferramentas)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Aparência tradicional) {toggletint2}
+            [exec] (Tampilan) {toggletint2}
         [end]
-        [submenu] (Papel de parede)
+        [submenu] (Carta)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
@@ -38,13 +38,13 @@
         [submenu] (Configurar)
             [exec] (Aplicações) {xdg-open ~/.fluxbox/apps}
             [exec] (Inicialização) {xdg-open ~/.fluxbox/init}
-            [exec] (Teclas) {xdg-open ~/.fluxbox/keys}
-            [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx_BR}
+            [exec] (Chaves) {xdg-open ~/.fluxbox/keys}
+            [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
             [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Início) {featherpad ~/.fluxbox/startup}
+            [exec] (Autostart) {featherpad ~/.fluxbox/startup}
             [exec] (Estilos) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Teclado)
+        [submenu] (Klawiatura)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (Fora de vista)
-            [exec] (Terminar dock) { killall wmalauncher               }
-    [exec] (Terminar uma janela) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Alternar conky) { conkytoggle.sh                    }
-    [exec] (Alternar iDesk) { idesktoggle idesk                 }
-    [exec] (Alternar ícones) { idesktoggle icons                 }
-    [exec] (Alternar auto-ocultar dock) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Alternar auto-ocultar barra de ferramentas) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Alternar monitores) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Desabilitar dock padrão) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
     [submenu] (Sair)
-        [exec] (Atualizar) { fluxbox-remote restart; idesktoggle idesk refresh }
+        [exec] (Actualização) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Suspender) {sudo 'pm-suspend'}
-        [exit] (Sair) 
-        [exec] (Reiniciar) {sudo /sbin/reboot} 
-        [exec] (Desligar) {sudo /sbin/halt}
+        [exit] (Uitloggen) 
+        [exec] (Uruchom) {sudo /sbin/reboot} 
+        [exec] (Encerramento) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/menu-mx_ru
+++ b/menu-translations/menu-mx_ru
@@ -10,7 +10,7 @@
     [exec] (Терминал) {xfce4-terminal} 
     [separator]
     [submenu] (Посмотреть) 
-        [exec] (Конки){conky-manager2}
+        [exec] (Conky Конки){conky-manager2}
         [submenu] (Доки)
             [exec] (По умолчанию) {~/.fluxbox/scripts/DefaultDock.mxdk}
             [separator]
@@ -26,25 +26,25 @@
         [exec] (Тема) {lxappearance}
         [submenu] (Панель инструментов)
             [exec] (Fluxbox) {toggletint2}
-            [exec] (Традиционный вид) {toggletint2}
+            [exec] (Tradisional) {toggletint2}
         [end]
-        [submenu] (Обои)
+        [submenu] (da)
             [wallpapers] (~/.fluxbox/backgrounds) {feh --bg-scale}
             [separator]
             [wallpapers] (/usr/share/backgrounds) {feh --bg-scale}
         [end]
     [end]
     [submenu] (Настройки)
-        [submenu] (Настройка)
+        [submenu] (Configurar)
             [exec] (Приложения) {xdg-open ~/.fluxbox/apps}
             [exec] (Ините) {xdg-open ~/.fluxbox/init}
-            [exec] (Ключи) {xdg-open ~/.fluxbox/keys}
+            [exec] (Chaveiro) {xdg-open ~/.fluxbox/keys}
             [exec] (Меню) {xdg-open ~/.fluxbox/menu-mx}
-            [exec] (Наложение) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Запуск) {featherpad ~/.fluxbox/startup}
+            [exec] (Nakładka) {xdg-open ~/.fluxbox/overlay}
+            [exec] (Arranque) {featherpad ~/.fluxbox/startup}
             [exec] (Стили) {thunar ~/.fluxbox/styles/}
         [end]
-        [submenu] (Клавиатура)
+        [submenu] (Teclado)
             [exec] (DE) {setxkbmap de}
 			      [exec] (ES) {setxkbmap es} 
 			      [exec] (FR) {setxkbmap fr}
@@ -61,24 +61,24 @@
         [exec] (Xfce) {xfce4-settings-manager}
     [end] 
     [separator]
-    [submenu] (С глаз долой)
-            [exec] (док-убийца) { killall wmalauncher               }
-    [exec] (Убить окно) { xkill                             }
+    [submenu] (Out of sight)
+            [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
     [separator]
-    [exec] (Тугл-конки) { conkytoggle.sh                    }
-    [exec] (Toggle iDesk) { idesktoggle idesk                 }
-    [exec] (переключающиеся иконки) { idesktoggle icons                 }
-    [exec] (Тоггл-автохидный док) { $HOME/.fluxbox/scripts/toggledock }
-    [exec] (Переключить автоматическую панель инструментов) {$HOME/.fluxbox/scripts/toggletoolbar}
-    [exec] (Тумблерные мониторы) { toggle-mx gkrellm                 }
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
     [separator]
-    [exec] (Отключить стандартную док-станцию) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
     [end]
-    [submenu] (Оставить)
-        [exec] (Обновить) { fluxbox-remote restart; idesktoggle idesk refresh }
+    [submenu] (Sair)
+        [exec] (Atualizar) { fluxbox-remote restart; idesktoggle idesk refresh }
         [exec] (Приостановить) {sudo 'pm-suspend'}
-        [exit] (Выход из системы) 
-        [exec] (Перезагрузить) {sudo /sbin/reboot} 
-        [exec] (Отключение) {sudo /sbin/halt}
+        [exit] (Wyloguj) 
+        [exec] (ponownie) {sudo /sbin/reboot} 
+        [exec] (Desligar) {sudo /sbin/halt}
     [end]
 [end]

--- a/menu-translations/out-of-sight_ar
+++ b/menu-translations/out-of-sight_ar
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_de
+++ b/menu-translations/out-of-sight_de
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_el
+++ b/menu-translations/out-of-sight_el
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_en
+++ b/menu-translations/out-of-sight_en
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_es
+++ b/menu-translations/out-of-sight_es
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_fr
+++ b/menu-translations/out-of-sight_fr
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_id
+++ b/menu-translations/out-of-sight_id
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_it
+++ b/menu-translations/out-of-sight_it
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_nl
+++ b/menu-translations/out-of-sight_nl
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_pl
+++ b/menu-translations/out-of-sight_pl
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_pt
+++ b/menu-translations/out-of-sight_pt
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_pt_BR
+++ b/menu-translations/out-of-sight_pt_BR
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/out-of-sight_ru
+++ b/menu-translations/out-of-sight_ru
@@ -1,0 +1,13 @@
+[begin] (Out of sight) 
+    [exec] (Kill dock            ) { killall wmalauncher               }
+    [exec] (Kill a window        ) { xkill                             }
+    [separator]
+    [exec] (Toggle conky         ) { conkytoggle.sh                    }
+    [exec] (Toggle iDesk         ) { idesktoggle idesk                 }
+    [exec] (Toggle icons         ) { idesktoggle icons                 }
+    [exec] (Toggle autohide dock ) { $HOME/.fluxbox/scripts/toggledock }
+    [exec] (Toggle autohide toolbar) {$HOME/.fluxbox/scripts/toggletoolbar}
+    [exec] (Toggle monitors      ) { toggle-mx gkrellm                 }
+    [separator]
+    [exec] (Disable default dock ) { killall wmalauncher && $HOME/.fluxbox/scripts/dfltdck_kill }
+[end]

--- a/menu-translations/settings_ar
+++ b/menu-translations/settings_ar
@@ -1,0 +1,32 @@
+[begin] (إعدادات)
+    [exec] (حول) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (ضبط)
+        [exec] (التطبيقات) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (مفاتيح) {xdg-open ~/.fluxbox/keys}
+        [exec] (قائمة) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
+        [exec] (بدء) {featherpad ~/.fluxbox/startup}
+        [exec] (أنماط) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](مساعدة) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (لوحة)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_de
+++ b/menu-translations/settings_de
@@ -1,0 +1,32 @@
+[begin] (Einstellungen)
+    [exec] (Über...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Konfigurieren)
+        [exec] (Anwendungen) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Schlüssel) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menü) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] () {xdg-open ~/.fluxbox/overlay}
+        [exec] (التشغيل) {featherpad ~/.fluxbox/startup}
+        [exec] (Stile) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Hilfe) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (المفاتيح)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_el
+++ b/menu-translations/settings_el
@@ -1,0 +1,32 @@
+[begin] (Ρυθμίσεις)
+    [exec] (Περί...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Configurer)
+        [exec] (Εφαρμογές) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Keys) {xdg-open ~/.fluxbox/keys}
+        [exec] (Μενού) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Superposición) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Startup) {featherpad ~/.fluxbox/startup}
+        [exec] (Στυλ) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Βοήθεια) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Clavier)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_en
+++ b/menu-translations/settings_en
@@ -1,0 +1,32 @@
+[begin] (Settings)
+    [exec] (About) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Configure)
+        [exec] (Apps) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Keys) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Startup) {featherpad ~/.fluxbox/startup}
+        [exec] (Styles) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Help) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Keyboard)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_es
+++ b/menu-translations/settings_es
@@ -1,0 +1,32 @@
+[begin] (Ajustes)
+    [exec] (Acerca de…) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Sie)
+        [exec] (Aplicaciones) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Llaves) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menú) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (تراكب) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Neugründung) {featherpad ~/.fluxbox/startup}
+        [exec] (Estilos) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Ayuda) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Tastatur)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_fr
+++ b/menu-translations/settings_fr
@@ -1,0 +1,32 @@
+[begin] (Paramètres)
+    [exec] (À propos…) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Configurar)
+        [exec] (Apps) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Clés) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Überlagerung) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Inicio) {featherpad ~/.fluxbox/startup}
+        [exec] (Styles) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Aide) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Teclado)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_id
+++ b/menu-translations/settings_id
@@ -1,0 +1,32 @@
+[begin] (Setelan)
+    [exec] (Tentang) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Διαμόρφωση)
+        [exec] (Aplikasi) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Tombol) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Superposition) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Startup) {featherpad ~/.fluxbox/startup}
+        [exec] (Gaya) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Bantuan) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Πληκτρολόγιο)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_it
+++ b/menu-translations/settings_it
@@ -1,0 +1,32 @@
+[begin] (Impostazioni)
+    [exec] (Info...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Konfigurasi)
+        [exec] (Applicazioni) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Tasti) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Επικάλυμμα) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Memulai) {featherpad ~/.fluxbox/startup}
+        [exec] (Stili) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Aiuto) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Papan)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_nl
+++ b/menu-translations/settings_nl
@@ -1,0 +1,32 @@
+[begin] (Instellingen)
+    [exec] (Over...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Configurare)
+        [exec] (Apps) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Toetsen) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Lembaran) {xdg-open ~/.fluxbox/overlay}
+        [exec] () {featherpad ~/.fluxbox/startup}
+        [exec] (Stijlen) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Help) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Ketik)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_pl
+++ b/menu-translations/settings_pl
@@ -1,0 +1,32 @@
+[begin] (Ustawienia)
+    [exec] (O...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Configureer)
+        [exec] (Aplikacje) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (Skróty) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Atas) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Avvio) {featherpad ~/.fluxbox/startup}
+        [exec] (Style) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Pomoc) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Tastiera)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_pt
+++ b/menu-translations/settings_pt
@@ -1,0 +1,32 @@
+[begin] (Definições)
+    [exec] (Sobre...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Konfiguracja)
+        [exec] (Apps) {xdg-open ~/.fluxbox/apps}
+        [exec] (Init) {xdg-open ~/.fluxbox/init}
+        [exec] (klawiszowe) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Sovrapposizione) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Opstarten) {featherpad ~/.fluxbox/startup}
+        [exec] (Estilos) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Ajuda) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Toetsenbord)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_pt_BR
+++ b/menu-translations/settings_pt_BR
@@ -1,0 +1,32 @@
+[begin] (Definições)
+    [exec] (Sobre...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Configurar)
+        [exec] (Aplicações) {xdg-open ~/.fluxbox/apps}
+        [exec] (Inicialização) {xdg-open ~/.fluxbox/init}
+        [exec] (Chaves) {xdg-open ~/.fluxbox/keys}
+        [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Autostart) {featherpad ~/.fluxbox/startup}
+        [exec] (Estilos) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Ajuda) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Klawiatura)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/menu-translations/settings_ru
+++ b/menu-translations/settings_ru
@@ -1,0 +1,32 @@
+[begin] (Настройки)
+    [exec] (O...) {about-mx-fluxbox}
+    [exec] (Backup) {grsync}
+    [submenu] (Configurar)
+        [exec] (Приложения) {xdg-open ~/.fluxbox/apps}
+        [exec] (Ините) {xdg-open ~/.fluxbox/init}
+        [exec] (Chaveiro) {xdg-open ~/.fluxbox/keys}
+        [exec] (Меню) {xdg-open ~/.fluxbox/menu-mx}
+        [exec] (Nakładka) {xdg-open ~/.fluxbox/overlay}
+        [exec] (Arranque) {featherpad ~/.fluxbox/startup}
+        [exec] (Стили) {thunar ~/.fluxbox/styles/}
+    [end]
+    [submenu] (Display) 
+    [exec] (Change) {arandr} 
+    [exec](Помощь) {featherpad ~/.fluxbox/components/HELP_Display} 
+    [end] 
+    [submenu] (Teclado)
+        [exec] (DE) {setxkbmap de}
+        [exec] (ES) {setxkbmap es} 
+        [exec] (FR) {setxkbmap fr}
+        [exec] (GB) {setxkbmap gb}
+        [exec] (GR) {setxkbmap gr}
+        [exec] (JA) {setxkbmap ja}
+        [exec] (IT) {setxkbmap it}
+        [exec] (PL) {setxkbmap pl}
+        [exec] (PT) {setxkbmap pt}
+        [exec] (RU) {setxkbmap ru}
+        [exec] (US) {setxkbmap us}
+    [end]
+    [config] (Fluxbox)
+    [exec] (Xfce) {xfce4-settings-manager}
+[end]

--- a/tools/MenuTransItems.csv
+++ b/tools/MenuTransItems.csv
@@ -1,49 +1,49 @@
-en,ar,de,es,fr,el,id,it,nl,pl,pt,pt_BR,ru,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-About,حول,Über...,Acerca de…,À propos…,Περί...,Tentang,Info...,Over...,O...,Sobre...,Sobre...,O...,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-All apps,جميع التطبيقات,Alle Anwendungen,Todas las aplicaciones,Toutes les applications,Όλες οι εφαρμογές,Semua Aplikasi,Tutte le applicazioni,Alle apps,Wszystkie aplikacje,Todas as aplicações,Todas as aplicações,Все приложения,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Browser,المتصفحالإلكتروني ,Browser,Navegador,Navigateur,Περιήγηση,Peramban,Browser,Browser,Przeglądarka,Browser,Navegador de internet,Браузер,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Email,البريد,E-Mail,Correo electrónico,Courriel,Ηλεκτρονική διεύθυνση,Email,E-mail,E-mail,E-mail,Email,Email,Email,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-File manager,مدير الملفات,Datei-Manager,Gestor de archivos,Gestionnaire de fichiers,Διαχείριση αρχείων,Pengelola Berkas,File manager,Bestandsmanager,Menedżer plików,Gestor de ficheiros,Gerenciador de arquivos,Менеджер файлов,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Help,مساعدة,Hilfe,Ayuda,Aide,Βοήθεια,Bantuan,Aiuto,Help,Pomoc,Ajuda,Ajuda,Помощь,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Music,موسيقى,Musik,Música,Musique,Μουσική,Musik,Musica,Muziek,Muzyka,Música,Música,Музыка,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Run,تشغيل,Führen Sie aus,Corre,Courir,Εκτέλεση,Jalankan,Esegui,Voer uit,Uruchom,Corre,Executar,Запустить,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Terminal,طرفية,Terminal,Terminal,Terminal,Τερματικό,Terminal,Terminale,Terminal,Terminal,Terminal,Terminal,Терминал,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Appearance,مظهر,Aussehen,Mira,Regardez,Εμφάνιση,Tampilan,Guarda,Verschijning,Wygląd,Veja,Aparência,Посмотреть,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Conky,كونكي,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky Конки,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Docks,شرائطالتطبيقات ,Docks,Muelles,Docks,Docks,Docks,Darsene,Dokken,Doki,Docas,Docks,Доки,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Default,افتراضي,Standardmäßig,Por defecto,Par défaut,Προκαθορισμένο,Setelan Bawaan,Predefinito,Standaard,Domyślny,Por defeito,Padrão,По умолчанию,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Dockmaker,معدّلشريط التطبيقات,Dockmaker,Dockmaker,Dockmaker,Dockmaker,DockMaker,Dockmaker,Dockmaker,Dockmaker,Dockmaker,Dockmaker,Докмейкер,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Desktop icons,أيقونات سطح المكتب,Desktop-Symbole,Iconos de escritorio,Icônes de bureau,Εικονίδια επιφάνειας εργασίας,Ikon Desktop,Icone da tavolo,Bureaupictogrammen,Ikony pulpitu,Ícones do ambiente de trabalho,Ícones da área de trabalho,Иконки рабочего стола,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Monitors,الشاشات,Überwacht,Monitores,Surveille,Έλεγχος,Layar,Monitor,Monitoren,Monitory,Monitores,Monitores,Мониторы,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Style,نسق,Stil,Estilo,Style,Στυλ,Gaya,Stile,Stijl,Styl,Estilo,Estilo,Стиль,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Theme,السمات,Thema,Tema,Thème,Θέμα,Tema,Tema,Thema,Motyw,Tema,Tema,Тема,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Toolbar,شريط الأدوات,Symbolleiste,Barra de herramientas,Barre d’outils,Γραμμή εργαλείων,Bilah Alat,Barra degli strumenti,Werkbalk,Pasek narzędzi,Barra de ferramentas,Barra de ferramentas,Панель инструментов,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallpaper,خلفية,الشاشة,Bildschirmhintergrund,Fondo,de,pantalla,Fond,d'écran,Ταπετσαρία,Wallpaper,Carta,da,parati,Behang,Tapeta,Wallpaper,Papel,de,parede,Обои,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Settings,إعدادات,Einstellungen,Ajustes,Paramètres,Ρυθμίσεις,Setelan,Impostazioni,Instellingen,Ustawienia,Definições,Definições,Настройки,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Configure,ضبط,Konfigurieren,Sie,Configurar,Configurer,Διαμόρφωση,Konfigurasi,Configurare,Configureer,Konfiguracja,Configurar,Configurar,Настройка,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Apps,التطبيقات,Anwendungen,Aplicaciones,Apps,Εφαρμογές,Aplikasi,Applicazioni,Apps,Aplikacje,Apps,Aplicações,Приложения,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Init,Init,Init,Init,Init,Init,Init,Init,Init,Init,Init,Inicialização,Ините,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Keys,مفاتيح,Schlüssel,Llaves,Clés,Keys,Tombol,Tasti,Toetsen,Skróty,klawiszowe,Chaves,Chaveiro,Ключи,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Menu,قائمة,Menü,Menú,Menu,Μενού,Menu,Menu,Menu,Menu,Menu,Menu,Меню,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Overlay,Overlay,,تراكب,Überlagerung,Superposición,Superposition,Επικάλυμμα,Lembaran,Atas,Sovrapposizione,Overlay,Nakładka,graficzna,Overlay,Overlay,Наложение,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Startup,بدء,التشغيل,Neugründung,Inicio,Startup,Startup,Memulai,,Avvio,Opstarten,Autostart,Arranque,Início,Запуск,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Styles,أنماط,Stile,Estilos,Styles,Στυλ,Gaya,Stili,Stijlen,Style,Estilos,Estilos,Стили,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Keyboard,لوحة,المفاتيح,Tastatur,Teclado,Clavier,Πληκτρολόγιο,Papan,Ketik,Tastiera,Toetsenbord,Klawiatura,Teclado,Teclado,Клавиатура,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Traditional,المظهر,التقليدي,Traditionelles,Aussehen,Aspecto,tradicional,Aspect,traditionnel,Παραδοσιακή,εμφάνιση,Tampilan,Tradisional,Look,tradizionale,Traditionele,uitstraling,Domyślny,wygląd,Aspecto,tradicional,Aparência,tradicional,Традиционный,вид,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Out,of,sight,خارج,النظر,Außer,Sichtweite,Fuera,de,la,vista,A,l'abri,des,regards,Κρυμμένα,Diluar,Pandangan,Lontano,dagli,occhi,Uit,het,zicht,Ukryj,Fora,de,vista,Fora,de,vista,С,глаз,долой,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Kill,dock,,,,,,,,,,,,,إنهاء,شريط,التطبيقات,Killdock,,,,,,,,,,,,,Muelle,de,la,muerte,,,,,,,,,,,,,Quai,d'extinction,,,,,,,,,,,,,Τερματισμός,dock,Matikan,Dock,Kill,dock,,,,,,,,,,,,,Dodendok,,,,,,,,,,,,,Zabij,dock,Cais,da,matança,,,,,,,,,,,,,Terminar,dock,док-убийца,,,,,,,,
-Kill,a,window,,,,,,,,,انهاء,نافذة,Ein,Fenster,töten,,,,,,,,,Matar,una,ventana,,,,,,,,,Tuer,une,fenêtre,,,,,,,,,Τερματισμός,παραθύρου,Matikan,Jendela,Uccidere,una,finestra,,,,,,,,,Dood,een,venster,,,,,,,,,Zabij,okno,Matar,uma,janela,,,,,,,,,Terminar,uma,janela,Убить,окно,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Toggle,conky,,,,,,,,,,إيقاف/تشغيل,Conky,Umschalten,conky,,,,,,,,,,Cambiar,conky...,,,,,,,,,,Toggle,conky,,,,,,,,,,Εναλλαγή,conky,,,,,,,,,,Tombol,Conky,Attivare,e,disattivare,il,conky,,,,,,,,,,Schakelen,tussen,conky,,,,,,,,,,Przełącznik,Conky,Alternar,conky,,,,,,,,,,Alternar,conky,,,,,,,,,,Тугл-конки,,,,,,,,,
-Toggle,iDesk,,,,,,,,,,إيقاف/تشغيل,iDesk,iDesk,umschalten,,,,,,,,,,Cambiar,el,iDesk,,,,,,,,,,Basculer,l'iDesk,,,,,,,,,,Εναλλαγή,iDesk,,,,,,,,,,Tombol,iDesk,Attivare,e,disattivare,l'iDesk,,,,,,,,,,Schakel,iDesk,,,,,,,,,,Przełącznik,iDesk,Toggle,iDesk,,,,,,,,,,Alternar,iDesk,Toggle,iDesk,,,,,,,,,,,,,,,,,,
-Toggle,icons,,,,,,,,,,إظهار/إخفاء,الأيقونات,,,,,,,,,,Symbole,umschalten,,,,,,,,,,Iconos,de,conmutación,,,,,,,,,,Icônes,de,basculement,,,,,,,,,,Εναλλαγή,εικονιδίων,,,,,,,,Tombol,ikon,Icone,a,levetta,,,,,,,,,,Schakelen,tussen,pictogrammen,,,,,,,,,,Przełącznik,ikon,pulpitu,Alternar,ícones,,,,,,,,,,Alternar,ícones,,,,,,,,,,переключающиеся,иконки
-Toggle,autohide,dock,,إيقاف/تشغيل,الاخفاء,التلقائي,لشريط,التطبيقات,Autohide-Dock,umschalten,,Cambiar,el,muelle,de,auto-ocultación,,Basculer,le,quai,autohide,,Εναλλαγή,autohide,dock,,Tombol,sembunyikan,otomatis,dock,Attivare,il,dock,autohide,,Schakelaar,voor,autodokker,,Przełącznik,autoukrywania,docku,Alternar,a,doca,de,autoculto,,Alternar,auto-ocultar,dock,Тоггл-автохидный,док,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Toggle,autohide,toolbar,إيقاف/تشغيل,الاخفاء,التلقائي,لشريط,الأدوات,Umschalten,der,Autohide-Werkzeugleiste,Cambiar,la,barra,de,herramientas,de,auto-ocultación,Barre,d'outils,de,masquage,automatique,Εναλλαγή,autohide,toolbar,Tombol,sembunyikan,otomatis,bilah,alat,Attivare,e,disattivare,la,barra,degli,strumenti,autohide,Schakel,de,autohide-werkbalk,in,Przełącznik,autoukrywania,paska,narzędzi,Alternar,a,barra,de,ferramentas,de,autoculto,Alternar,auto-ocultar,barra,de,ferramentas,Переключить,автоматическую,панель,инструментов,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Toggle,monitors,,,,,,,تبديل,الشاشات,,,,,,,Monitore,umschalten,,,,,,,Cambiar,los,monitores...,,,,,,,Basculer,les,moniteurs,,,,,,,Εναλλαγή,monitors,,,,,,,Tombol,monitor,Monitor,a,levetta,,,,,,,Schakelen,tussen,de,monitoren,,,,,,,Przełącznik,monitorów,Monitores,Toggle,,,,,,,Alternar,monitores,Тумблерные,мониторы,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Disable,default,dock,,تعطيل,شريط,التطبيقات,الافتراضي,Standard-Dock,deaktivieren,,Deshabilitar,el,acoplamiento,por,defecto,,Désactiver,le,dock,par,défaut,,Απενεργοποίηση,προεπιλεγμένο,dock,,Matikan,setelan,bawaan,dock,Disattivare,il,dock,di,default,,Standaard,dok,uitschakelen,,Wyłącz,domyślny,dock,Desactivar,a,doca,por,defeito,,Desabilitar,dock,padrão,Отключить,стандартную,док-станцию,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Leave,مغادرة,Verlassen,Sie,Deje,Quitter,Εξοδος,Meninggalkan,Lascia,Verlaat,Wyjdź,Sair,Sair,Оставить,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Refresh,تحديث,Aktualisieren,Sie,Actualizar,Rafraîchir,Ανανέωση,Segarkan,Aggiorna,Vernieuwen,Odśwież,Actualização,Atualizar,Обновить,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Suspend,تعليق,aussetzen,Suspender,Suspendre,Αναστολή,Suspend,Sospendi,Schorsen,Wstrzymaj,Suspendam,Suspender,Приостановить,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Logout,تسجيل,الخروج,Abmeldung,Cierre,de,sesión,Déconnexion,Αποσύνδεση,Keluar,Logout,Uitloggen,Wyloguj,Sair,Sair,Выход,из,системы,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Reboot,إعادة,التشغيل,Neustart,Reiniciar,Redémarrer,Επανεκκινήση,Mulai,ulang,Riavvio,Herstart,Uruchom,ponownie,Reinicialização,Reiniciar,Перезагрузить,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Shutdown,إيقاف,التشغيل,Herunterfahren,Apagado,Fermeture,Τερματισμός,Matikan,Spegnimento,Uitschakeling,Zamknij,Encerramento,Desligar,Отключение,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+en,ar,de,es,fr,el,id,it,nl,pl,pt,pt_BR,ru
+Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox,Fluxbox
+About,حول,Über...,Acerca de…,À propos…,Περί...,Tentang,Info...,Over...,O...,Sobre...,Sobre...,O...
+All apps,جميع التطبيقات,Alle Anwendungen,Todas las aplicaciones,Toutes les applications,Όλες οι εφαρμογές,Semua Aplikasi,Tutte le applicazioni,Alle apps,Wszystkie aplikacje,Todas as aplicações,Todas as aplicações,Все приложения
+Browser,المتصفحالإلكتروني ,Browser,Navegador,Navigateur,Περιήγηση,Peramban,Browser,Browser,Przeglądarka,Browser,Navegador de internet,Браузер
+Email,البريد,E-Mail,Correo electrónico,Courriel,Ηλεκτρονική διεύθυνση,Email,E-mail,E-mail,E-mail,Email,Email,Email
+File manager,مدير الملفات,Datei-Manager,Gestor de archivos,Gestionnaire de fichiers,Διαχείριση αρχείων,Pengelola Berkas,File manager,Bestandsmanager,Menedżer plików,Gestor de ficheiros,Gerenciador de arquivos,Менеджер файлов
+Help,مساعدة,Hilfe,Ayuda,Aide,Βοήθεια,Bantuan,Aiuto,Help,Pomoc,Ajuda,Ajuda,Помощь
+Music,موسيقى,Musik,Música,Musique,Μουσική,Musik,Musica,Muziek,Muzyka,Música,Música,Музыка
+Run,تشغيل,Führen Sie aus,Corre,Courir,Εκτέλεση,Jalankan,Esegui,Voer uit,Uruchom,Corre,Executar,Запустить
+Terminal,طرفية,Terminal,Terminal,Terminal,Τερματικό,Terminal,Terminale,Terminal,Terminal,Terminal,Terminal,Терминал
+Appearance,مظهر,Aussehen,Mira,Regardez,Εμφάνιση,Tampilan,Guarda,Verschijning,Wygląd,Veja,Aparência,Посмотреть
+Conky,كونكي,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky,Conky Конки
+Docks,شرائطالتطبيقات ,Docks,Muelles,Docks,Docks,Docks,Darsene,Dokken,Doki,Docas,Docks,Доки
+Default,افتراضي,Standardmäßig,Por defecto,Par défaut,Προκαθορισμένο,Setelan Bawaan,Predefinito,Standaard,Domyślny,Por defeito,Padrão,По умолчанию
+Dockmaker,معدّلشريط التطبيقات,Dockmaker,Dockmaker,Dockmaker,Dockmaker,DockMaker,Dockmaker,Dockmaker,Dockmaker,Dockmaker,Dockmaker,Докмейкер
+Desktop icons,أيقونات سطح المكتب,Desktop-Symbole,Iconos de escritorio,Icônes de bureau,Εικονίδια επιφάνειας εργασίας,Ikon Desktop,Icone da tavolo,Bureaupictogrammen,Ikony pulpitu,Ícones do ambiente de trabalho,Ícones da área de trabalho,Иконки рабочего стола
+Monitors,الشاشات,Überwacht,Monitores,Surveille,Έλεγχος,Layar,Monitor,Monitoren,Monitory,Monitores,Monitores,Мониторы
+Style,نسق,Stil,Estilo,Style,Στυλ,Gaya,Stile,Stijl,Styl,Estilo,Estilo,Стиль
+Theme,السمات,Thema,Tema,Thème,Θέμα,Tema,Tema,Thema,Motyw,Tema,Tema,Тема
+Toolbar,شريط الأدوات,Symbolleiste,Barra de herramientas,Barre d’outils,Γραμμή εργαλείων,Bilah Alat,Barra degli strumenti,Werkbalk,Pasek narzędzi,Barra de ferramentas,Barra de ferramentas,Панель инструментов
+Wallpaper,خلفية,الشاشة,Bildschirmhintergrund,Fondo,de,pantalla,Fond,d'écran,Ταπετσαρία,Wallpaper,Carta,da
+Settings,إعدادات,Einstellungen,Ajustes,Paramètres,Ρυθμίσεις,Setelan,Impostazioni,Instellingen,Ustawienia,Definições,Definições,Настройки
+Configure,ضبط,Konfigurieren,Sie,Configurar,Configurer,Διαμόρφωση,Konfigurasi,Configurare,Configureer,Konfiguracja,Configurar,Configurar
+Apps,التطبيقات,Anwendungen,Aplicaciones,Apps,Εφαρμογές,Aplikasi,Applicazioni,Apps,Aplikacje,Apps,Aplicações,Приложения
+Init,Init,Init,Init,Init,Init,Init,Init,Init,Init,Init,Inicialização,Ините
+Keys,مفاتيح,Schlüssel,Llaves,Clés,Keys,Tombol,Tasti,Toetsen,Skróty,klawiszowe,Chaves,Chaveiro
+Menu,قائمة,Menü,Menú,Menu,Μενού,Menu,Menu,Menu,Menu,Menu,Menu,Меню
+Overlay,Overlay,,تراكب,Überlagerung,Superposición,Superposition,Επικάλυμμα,Lembaran,Atas,Sovrapposizione,Overlay,Nakładka
+Startup,بدء,التشغيل,Neugründung,Inicio,Startup,Startup,Memulai,,Avvio,Opstarten,Autostart,Arranque
+Styles,أنماط,Stile,Estilos,Styles,Στυλ,Gaya,Stili,Stijlen,Style,Estilos,Estilos,Стили
+Keyboard,لوحة,المفاتيح,Tastatur,Teclado,Clavier,Πληκτρολόγιο,Papan,Ketik,Tastiera,Toetsenbord,Klawiatura,Teclado
+Traditional,المظهر,التقليدي,Traditionelles,Aussehen,Aspecto,tradicional,Aspect,traditionnel,Παραδοσιακή,εμφάνιση,Tampilan,Tradisional
+Out,of,sight,خارج,النظر,Außer,Sichtweite,Fuera,de,la,vista,A,l'abri
+Kill,dock,,,,,,,,,,,
+Kill,a,window,,,,,,,,,انهاء,نافذة
+Toggle,conky,,,,,,,,,,إيقاف/تشغيل,Conky
+Toggle,iDesk,,,,,,,,,,إيقاف/تشغيل,iDesk
+Toggle,icons,,,,,,,,,,إظهار/إخفاء,الأيقونات
+Toggle,autohide,dock,,إيقاف/تشغيل,الاخفاء,التلقائي,لشريط,التطبيقات,Autohide-Dock,umschalten,,Cambiar
+Toggle,autohide,toolbar,إيقاف/تشغيل,الاخفاء,التلقائي,لشريط,الأدوات,Umschalten,der,Autohide-Werkzeugleiste,Cambiar,la
+Toggle,monitors,,,,,,,تبديل,الشاشات,,,
+Disable,default,dock,,تعطيل,شريط,التطبيقات,الافتراضي,Standard-Dock,deaktivieren,,Deshabilitar,el
+Leave,مغادرة,Verlassen,Sie,Deje,Quitter,Εξοδος,Meninggalkan,Lascia,Verlaat,Wyjdź,Sair,Sair
+Refresh,تحديث,Aktualisieren,Sie,Actualizar,Rafraîchir,Ανανέωση,Segarkan,Aggiorna,Vernieuwen,Odśwież,Actualização,Atualizar
+Suspend,تعليق,aussetzen,Suspender,Suspendre,Αναστολή,Suspend,Sospendi,Schorsen,Wstrzymaj,Suspendam,Suspender,Приостановить
+Logout,تسجيل,الخروج,Abmeldung,Cierre,de,sesión,Déconnexion,Αποσύνδεση,Keluar,Logout,Uitloggen,Wyloguj
+Reboot,إعادة,التشغيل,Neustart,Reiniciar,Redémarrer,Επανεκκινήση,Mulai,ulang,Riavvio,Herstart,Uruchom,ponownie
+Shutdown,إيقاف,التشغيل,Herunterfahren,Apagado,Fermeture,Τερματισμός,Matikan,Spegnimento,Uitschakeling,Zamknij,Encerramento,Desligar

--- a/tools/fluxbox.R
+++ b/tools/fluxbox.R
@@ -1,5 +1,5 @@
 # Localize base file(s) based on a translations file
-# 2021-05-14 BBL
+# 2021-05-14 Ben Bond-Lamberty
 
 BASE_FILES <- list.files(pattern = "_template")
 
@@ -15,7 +15,6 @@ message("Number of mappings = ", nrow(mappings))
 message("Eliminating spaces before and after close and open parens")
 
 for(bf in BASE_FILES) {
-  
   message("------------------------------------")
   message("Processing ", bf)
   base <- readLines(bf)
@@ -27,6 +26,7 @@ for(bf in BASE_FILES) {
     
     trans <- base
     trcount <- 0
+    
     for(j in seq_len(nrow(mappings))) {
       # First column holds the English term to translate
       term <- paste0("\\(", trimws(mappings[j, 1]), "[[:space:]]*\\)")

--- a/tools/fluxbox.R
+++ b/tools/fluxbox.R
@@ -1,10 +1,7 @@
 # Localize base file(s) based on a translations file
 # 2021-05-14 BBL
 
-BASE_FILES <- c("menu-mx_template",
-                "appearance_template",
-                "settings_template",
-                "out-of-sight_template")
+BASE_FILES <- list.files(pattern = "_template")
 
 TRANSLATIONS <- "MenuTransItems.csv"
 
@@ -12,7 +9,8 @@ OUTPUT_DIR <- "../menu-translations/"
 
 mappings <- read.csv(TRANSLATIONS)
 message("Welcome to fluxbox_trans.R")
-message("I see ", ncol(mappings) - 1, " translations to make ")
+message("I see ", length(BASE_FILES), " base template files")
+message("I see ", ncol(mappings) - 1, " translations to make")
 message("Number of mappings = ", nrow(mappings))
 message("Eliminating spaces before and after close and open parens")
 

--- a/tools/fluxbox.R
+++ b/tools/fluxbox.R
@@ -8,6 +8,8 @@ BASE_FILES <- c("menu-mx_template",
 
 TRANSLATIONS <- "MenuTransItems.csv"
 
+OUTPUT_DIR <- "../menu-translations/"
+
 mappings <- read.csv(TRANSLATIONS)
 message("Welcome to fluxbox_trans.R")
 message("I see ", ncol(mappings) - 1, " translations to make ")
@@ -19,7 +21,6 @@ for(bf in BASE_FILES) {
   message("------------------------------------")
   message("Processing ", bf)
   base <- readLines(bf)
-  
   
   for(i in seq_along(mappings)) {
     message("------------------------------------")
@@ -51,7 +52,7 @@ for(bf in BASE_FILES) {
       outfile <- paste(gsub("_template", "", bf), lang, sep = "_")
       message("Translated ", trcount, " terms")
       message("Writing ", outfile)
-      writeLines(trans, outfile)
+      writeLines(trans, file.path(OUTPUT_DIR, outfile))
     } # for j
   } # for i
 } # for bf

--- a/tools/fluxbox.R
+++ b/tools/fluxbox.R
@@ -1,48 +1,59 @@
+# Localize base file(s) based on a translations file
+# 2021-05-14 BBL
 
+BASE_FILES <- c("menu-mx_template",
+                "appearance_template",
+                "settings_template",
+                "out-of-sight_template")
 
-BASE_FILE <- "menu-mx_template"
 TRANSLATIONS <- "MenuTransItems.csv"
-OUT_FILE <- "menu-mx" 
 
 mappings <- read.csv(TRANSLATIONS)
-base <- readLines(BASE_FILE)
-
 message("Welcome to fluxbox_trans.R")
 message("I see ", ncol(mappings) - 1, " translations to make ")
 message("Number of mappings = ", nrow(mappings))
-
 message("Eliminating spaces before and after close and open parens")
 
-for(i in seq_along(mappings)) {
-  message("------------------------------------")
-  lang <- colnames(mappings)[i]
-  message(lang)
+for(bf in BASE_FILES) {
   
-  trans <- base
-  trcount <- 0
-  for(j in seq_len(nrow(mappings))) {
-    # First column holds the English term to translate
-    term <- paste0("\\(", trimws(mappings[j, 1]), "[[:space:]]*\\)")
+  message("------------------------------------")
+  message("Processing ", bf)
+  base <- readLines(bf)
+  
+  
+  for(i in seq_along(mappings)) {
+    message("------------------------------------")
+    lang <- colnames(mappings)[i]
+    message(lang)
     
-    # jth column holds translated term
-    transterm <- paste0("(", trimws(mappings[j, i]), ")")
-    
-    
-    if(transterm != "" & !is.na(transterm)) {
-      if(any(grepl(term, base))) {
-        # message("\t", term, " -> ", transterm)
-        trans <- gsub(term, transterm, trans)
-        trcount <- trcount + 1
+    trans <- base
+    trcount <- 0
+    for(j in seq_len(nrow(mappings))) {
+      # First column holds the English term to translate
+      term <- paste0("\\(", trimws(mappings[j, 1]), "[[:space:]]*\\)")
+      
+      # jth column holds translated term
+      transterm <- paste0("(", trimws(mappings[j, i]), ")")
+      
+      if(transterm != "" & !is.na(transterm)) {
+        if(any(grepl(term, base))) {
+          # message("\t", term, " -> ", transterm)
+          trans <- gsub(term, transterm, trans)
+          trcount <- trcount + 1
+        } else {
+          message("\tNot found: ", term)
+        }
       } else {
-        message("\tNot found: ", term)
+        message("\tNo translation provided for ", term)
       }
-    } else {
-      message("\tNo translation provided for ", term)
-    }
-    
-    outfile <- paste(OUT_FILE, lang, sep = "_")
-    message("Translated ", trcount, " terms")
-    message("Writing ", outfile)
-    writeLines(trans, outfile)
-  }
-}
+      
+      # Write the language-specific output file
+      outfile <- paste(gsub("_template", "", bf), lang, sep = "_")
+      message("Translated ", trcount, " terms")
+      message("Writing ", outfile)
+      writeLines(trans, outfile)
+    } # for j
+  } # for i
+} # for bf
+
+message("All done.")


### PR DESCRIPTION
This PR upgrades the R script to handle _arbitrary_ number of base (i.e. template) files.

The script searches for these ("_template") in the working directory, then uses `MenuTransItemsd.csv` to translate all terms into the various languages. The resulting files are written to `../menu-translations/`. 